### PR TITLE
Open other folder on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 A flutter plugin to open the default file manager app.
 
 ## Support
-|             | Android | iOS     |
-|-------------|---------|---------|
-| **Support** | SDK 20+ | iOS 12+ |
+|             | Android     | iOS     |
+|-------------|-------------|---------|
+| **Support** | SDK 20+ *   | iOS 12+ |
+
+- The `Other` folder feature requires SDK 26 and above on Android.
 
 ## How it works?
 
 ### Android
-The `Android` app can open either `Recent` folder or `Download` folder.
+The `Android` app can open either `Recent` folder, `Download` folder, or `Other` folder.
 The plugin will show the available file manager apps in the bottom popup and you can select one app to open.
 That app will open with the given folder in selected app.
 
@@ -21,7 +23,7 @@ Also, you need to save at least one file to view your app's folder.
 <key>UISupportsDocumentBrowser</key>  
 <true/>
 ```
-  
+
 ## Usage
 
 It's a very simple to use. Just call the below method and add `config` if required.
@@ -43,6 +45,28 @@ openFileManager(
  - If `androidConfig` doesn't provided, Android app will open `Download` folder by default.
  - If `iosConfig` doesn't provided, iOS app will open app's document folder by default.
 
+### Open `Other` folder on Android
+
+To open `Other` folder on Android, you can use the following code snippet:
+
+```dart
+import 'package:open_file_manager/open_file_manager.dart';
+
+openFileManager(
+    androidConfig: AndroidConfig(
+        folderType: FolderType.other,
+        folderPath: 'Pictures/Screenshots',
+    ),
+);
+```
+
+The `folderPath` supports the following path formats:
+
+- `Pictures/Screenshots`
+- `/storage/emulated/0/Pictures/Screenshots`
+- `/storage/243F-4E12/Pictures/Screenshots`
+
+If `folderPath` is not provided or does not exist, the `Recent` folder will be opened.
 
 ## Preview
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,9 +15,14 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final _androidFolderTypes = [FolderType.recent, FolderType.download];
+  final _androidFolderTypes = [
+    FolderType.recent,
+    FolderType.download,
+    FolderType.other,
+  ];
   var _selectedFolderType = FolderType.download;
   final _subFolderPathCtrl = TextEditingController();
+  final _otherFolderPathCtrl = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +56,21 @@ class _MyAppState extends State<MyApp> {
                   },
                 ),
               ),
+              if (_selectedFolderType == FolderType.other) ...[
+                const Text(
+                  'Write Android folder path',
+                  style: TextStyle(fontSize: 20),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: TextFormField(
+                    controller: _otherFolderPathCtrl,
+                    decoration: const InputDecoration(
+                      hintText: 'Folder path',
+                    ),
+                  ),
+                ),
+              ],
             ],
             if (Platform.isIOS) ...[
               const Text(
@@ -73,6 +93,7 @@ class _MyAppState extends State<MyApp> {
                 openFileManager(
                   androidConfig: AndroidConfig(
                     folderType: _selectedFolderType,
+                    folderPath: _otherFolderPathCtrl.text.trim(),
                   ),
                   iosConfig: IosConfig(
                     subFolderPath: _subFolderPathCtrl.text.trim(),

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -3,7 +3,10 @@ final class AndroidConfig {
   /// Type of folder to open.
   final FolderType folderType;
 
-  AndroidConfig({required this.folderType});
+  /// Folder path to open on folder type `other`
+  final String? folderPath;
+
+  AndroidConfig({required this.folderType, this.folderPath});
 }
 
 /// Configuration class for iOS platform.
@@ -20,5 +23,8 @@ enum FolderType {
   recent,
 
   /// Download folder
-  download
+  download,
+
+  /// Other folder
+  other,
 }

--- a/lib/src/open_file_manager_method_channel.dart
+++ b/lib/src/open_file_manager_method_channel.dart
@@ -20,6 +20,7 @@ class MethodChannelOpenFileManager extends OpenFileManagerPlatform {
     final data = <String, dynamic>{};
     if (Platform.isAndroid && androidConfig != null) {
       data['folderType'] = androidConfig.folderType.name;
+      data['folderPath'] = androidConfig.folderPath;
     } else if (Platform.isIOS && iosConfig != null) {
       data['subFolderPath'] = iosConfig.subFolderPath;
     }


### PR DESCRIPTION
Add `FolderType.other` on `AndroidConfig`, to open other folder. 

Requires SDK 26 and above

### Tested folders
- `Pictures/Screenshots`
- `/storage/emulated/0/Pictures/Screenshots`
- `/storage/243F-4E12/Pictures/Screenshots`

